### PR TITLE
Level up private package generation

### DIFF
--- a/generators/app/goodeggs_npm.coffee
+++ b/generators/app/goodeggs_npm.coffee
@@ -48,10 +48,21 @@ module.exports = class GoodeggsNpmGenerator extends yeoman.generators.Base
       }
       {
         type: 'list'
+        name: 'private'
+        message: 'Is this a private Good Eggs-only package or Open Source?'
+        default: true
+        choices: [
+          {name: 'Private', value: true}
+          {name: 'Open Source', value: false}
+        ]
+      }
+      {
+        type: 'list'
         name: 'license'
         message: 'What license would you like to use?'
-        choices: ['Private', 'MIT', 'LGPL']
-        default: 'Private'
+        choices: ['MIT', 'LGPL']
+        default: 'MIT'
+        when: (answers) -> not answers.private
       }
       {
         type: 'list'
@@ -63,10 +74,11 @@ module.exports = class GoodeggsNpmGenerator extends yeoman.generators.Base
         ]
       }
     ]
-    @prompt prompts, ({framework, @pkgtitle, @description, @license}) =>
+    @prompt prompts, ({framework, @pkgtitle, @description, @private, @license}) =>
       @pkgname = @_.dasherize @pkgtitle.toLowerCase()
       @angular = framework is 'angular'
-      @private = @license is 'Private'
+      if @private
+        @license = 'Private'
       cb()
 
   gitUser: ->
@@ -87,7 +99,7 @@ module.exports = class GoodeggsNpmGenerator extends yeoman.generators.Base
     @copy 'gitignore', '.gitignore'
     @copy 'travis.yml', '.travis.yml'
     @copy "LICENSE_#{@license}.md", 'LICENSE.md' unless @private
-    @copy 'CODE_OF_CONDUCT.md', 'CODE_OF_CONDUCT.md'
+    @copy 'CODE_OF_CONDUCT.md', 'CODE_OF_CONDUCT.md' unless @private
     @template '_bower.json', 'bower.json' if @angular
     @template '_README.md', 'README.md'
 

--- a/generators/package_json.coffee
+++ b/generators/package_json.coffee
@@ -6,6 +6,8 @@ module.exports = (data, overrides={}) ->
   json = base.apply(data)
   if data.angular
     json = merge json, angular.apply(data)
+  if data.private
+    json = merge json, puhrivate.apply(data)
   json = merge json, overrides
   JSON.stringify json, null, 2
 
@@ -14,7 +16,6 @@ module.exports = (data, overrides={}) ->
 base = ->
   name: @pkgname
   version: "0.0.0"
-  private: @private or undefined
   description: @description
   author: "Good Eggs <open-source@goodeggs.com>"
   contributors: @contributors and @contributors.map helpers.user
@@ -59,3 +60,8 @@ js = ->
     jshint: '*'
   scripts:
     test: "jshint *.js && mocha"
+
+puhrivate = ->
+  publishConfig:
+    registry: "https://goodeggs.registry.nodejitsu.com/"
+    'always-auth': true

--- a/generators/templates/_README.md
+++ b/generators/templates/_README.md
@@ -1,16 +1,17 @@
 # {{ pkgtitle }}
 
-{{~#unless angular}}
-[![NPM version](https://badge.fury.io/js/{{ pkgname }}.png)](http://badge.fury.io/js/{{ pkgname }})
-{{/unless}}
-
-{{#if private}}
-[![Build Status](https://magnum.travis-ci.com/goodeggs/{{ reposlug }}.png)](https://magnum.travis-ci.com/goodeggs/{{ reposlug }})
-{{else}}
-[![Build Status](https://travis-ci.org/goodeggs/{{ reposlug }}.png)](https://travis-ci.org/goodeggs/{{ reposlug }})
-{{/if}}
-
 {{ description }}
+
+{{#if private~}}
+
+[![Build Status](https://magnum.travis-ci.com/goodeggs/{{ reposlug }}.png)](https://magnum.travis-ci.com/goodeggs/{{ reposlug }})
+{{else}}{{#unless angular~}}
+
+[![NPM version](https://badge.fury.io/js/{{ pkgname }}.png)](https://www.npmjs.org/package/{{ pkgname }})
+{{/unless~}}
+
+[![Build Status](https://travis-ci.org/goodeggs/{{ reposlug }}.png)](https://travis-ci.org/goodeggs/{{ reposlug }})
+{{~/if}}
 
 ## Contributing
 
@@ -20,12 +21,12 @@ $ npm install
 $ npm test
 ```
 
+{{~#unless private}}
 ## Code of Conduct
 
 [Code of Conduct](https://github.com/goodeggs/{{ pkgname }}/blob/master/CODE_OF_CONDUCT.md)
 for contributing to or participating in this project.
 
-{{~#unless private}}
 ## License
 
 [{{ license }}](https://github.com/goodeggs/{{ pkgname }}/blob/master/LICENSE.md)

--- a/test/files.spec.coffee
+++ b/test/files.spec.coffee
@@ -4,6 +4,7 @@ helpers = require('yeoman-generator').test
 assert = require('yeoman-generator').assert
 
 describe 'goodeggs-npm generated files', ->
+
   describe 'with default prompt values', ->
     before (done) ->
       @runGenerator {}, done
@@ -24,11 +25,6 @@ describe 'goodeggs-npm generated files', ->
       it 'adds contributors', ->
         assert.fileContent 'package.json', /"contributors":/
 
-    describe 'README.md', ->
-      it 'includes badges', ->
-        assert.fileContent 'README.md', /// travis-ci ///
-        assert.fileContent 'README.md', /// badge.fury.io/js ///
-
   describe 'when user supplies a package name and description', ->
     pkgtitle = 'French Omelette'
     description = "Dish made from beaten eggs quickly cooked with butter or oil in a frying pan"
@@ -48,4 +44,49 @@ describe 'goodeggs-npm generated files', ->
       it 'includes package name and description', ->
         assert.fileContent 'README.md', /// #{pkgtitle} ///
         assert.fileContent 'README.md', /// #{description} ///
+
+  describe 'private package', ->
+    before (done) ->
+      @runGenerator {private: true}, done
+
+    it 'excludes code of conduct', ->
+      assert.noFile 'CODE_OF_CONDUCT.md'
+
+    it 'has no license file', ->
+      assert.noFile 'LICENSE.md'
+
+    describe 'package.json', ->
+      it 'flags the package as private', ->
+        assert.fileContent 'package.json', /// "license":\s"Private" ///
+
+      it 'restricts publishing to our private registry', ->
+        assert.fileContent 'package.json', /"publishConfig":/
+        assert.fileContent 'package.json', /https:\/\/goodeggs\.registry/
+
+    describe 'README.md', ->
+      it 'includes private badges', ->
+        assert.noFileContent 'README.md', /// badge.*npmjs\.org ///
+        assert.fileContent 'README.md', /// magnum\.travis-ci\.com.*\.png ///
+
+  describe 'open source package', ->
+    before (done) ->
+      @runGenerator {private: false}, done
+
+    it 'includes code of conduct', ->
+      assert.file 'CODE_OF_CONDUCT.md'
+
+    it 'has a license file', ->
+      assert.file 'LICENSE.md'
+
+    describe 'package.json', ->
+      it 'omits publishConfig', ->
+        assert.noFileContent 'package.json', /"publishConfig":/
+
+    describe 'README.md', ->
+      it 'includes public badges', ->
+        assert.fileContent 'README.md', /// badge.*npmjs\.org ///
+        assert.fileContent 'README.md', /// travis-ci\.org.*\.png ///
+
+      it 'leaves no empty lines in between the badegs so they flow nicely', ->
+        assert.fileContent 'README.md', /NPM version.*\n.*Build Status/
 


### PR DESCRIPTION
Biggest win is package.json [publishConfig](https://www.npmjs.org/doc/files/package.json.html#publishconfig), preventing us from publishing private modules anywhere but our private registry.

Other win is test coverage.  Especially around the most critical piece, spacing between badges in README.md!

Fixes #13, although I'm not sure about the CODE_OF_CONDUCT part.  I think it's meant to apply to open source projects, but doesn't seem harmful to leave it in. Strong feelings?

PS, have you all see [scoped packages](https://github.com/npm/npm/issues/5239) coming in npm 1.5?  @goodeggs/module-name always forwards to a configured private repo! :balloon: 
