### PR TITLE
Embrace npmignore defaults

### DIFF
--- a/generators/templates/npmignore
+++ b/generators/templates/npmignore
@@ -1,6 +1,4 @@
 .editorconfig
-.git/
 .gitignore
 .travis.yml
-npm-debug.log
 test/


### PR DESCRIPTION
@demands looks like `.git` and `npm-debug.log` are [ignored by default](https://www.npmjs.org/doc/misc/npm-developers.html#keeping-files-out-of-your-package).  Any reason to keep them?
